### PR TITLE
Add algorithm stub and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@
     * @param {Object} params
     * @returns {{ tradeDate: string, action: 'buy'|'sell', amount: number }}[]
     */
-   export function simulateTrades(history, cashBalance, params) {
-     // ここに投資アルゴリズムを書きます
-   }
-   ```
+  export function simulateTrades(history, cashBalance, params) {
+    // ここに投資アルゴリズムを書きます
+  }
+  ```
+   デフォルトでは何もしないダミー実装が入っています。独自のロジックに書き換えてください。
 3. **パラメータ設定**：UIのフォームから開始日、終了日に加え、月次追加額（デフォルト10万円）も指定できます。
 4. **シミュレーション実行**：`シミュレーション開始` ボタンを押すと、バックテストが実行され、チャートと表が更新されます。
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "http-server -p 3000 -c-1 .",
     "lint": "eslint .",
     "build": "rm -rf dist && mkdir dist && cp -r public dist && cp -r src dist && cp public/index.html dist/index.html && cp public/style.css dist/style.css && sed -i 's|../src/main.js|src/main.js|' dist/index.html",
-    "test": "node test/test.js && node test/paifuExporter.test.js && node test/exportCSV.test.js && node test/build.test.js"
+    "test": "node test/algorithm.test.js && node test/test.js && node test/paifuExporter.test.js && node test/exportCSV.test.js && node test/build.test.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/algorithm.js
+++ b/src/algorithm.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Placeholder trading algorithm.
+ *
+ * @param {Array<{ date: string, price: number }>} history - Price history.
+ * @param {number} cashBalance - Available cash.
+ * @param {Object} params - Optional strategy parameters.
+ * @returns {{ tradeDate: string, action: 'buy'|'sell', amount: number }[]} List of trades.
+ */
+export function simulateTrades(history, cashBalance, params) {
+  // TODO: implement your trading algorithm here
+  return [];
+}

--- a/test/algorithm.test.js
+++ b/test/algorithm.test.js
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import { simulateTrades } from '../src/algorithm.js';
+
+const trades = simulateTrades([], 100000, {});
+assert(Array.isArray(trades), 'simulateTrades should return an array');
+console.log('algorithm tests passed');


### PR DESCRIPTION
## Summary
- add placeholder `simulateTrades` in `src/algorithm.js`
- add unit test ensuring module loads
- include new test in npm script
- document stub algorithm in README

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a3218e54c832aa42e3264d0c644b0