### PR TITLE
Implement buy-and-hold algorithm and add tests

### DIFF
--- a/src/algorithm.js
+++ b/src/algorithm.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /**
  * Placeholder trading algorithm.
  *
@@ -8,6 +7,12 @@
  * @returns {{ tradeDate: string, action: 'buy'|'sell', amount: number }[]} List of trades.
  */
 export function simulateTrades(history, cashBalance, params) {
-  // TODO: implement your trading algorithm here
-  return [];
+  const buyAmount = (params && params.buyAmount) || 10000;
+  const trades = [];
+  for (const entry of history) {
+    if (cashBalance < buyAmount) break;
+    trades.push({ tradeDate: entry.date, action: 'buy', amount: buyAmount });
+    cashBalance -= buyAmount;
+  }
+  return trades;
 }

--- a/test/algorithm.test.js
+++ b/test/algorithm.test.js
@@ -1,6 +1,22 @@
 import assert from 'assert';
 import { simulateTrades } from '../src/algorithm.js';
 
-const trades = simulateTrades([], 100000, {});
+const history = [
+  { date: '2024-01-01', price: 100 },
+  { date: '2024-02-01', price: 110 },
+  { date: '2024-03-01', price: 120 }
+];
+
+// Default buyAmount (10000)
+const trades = simulateTrades(history, 25000, {});
 assert(Array.isArray(trades), 'simulateTrades should return an array');
+assert.strictEqual(trades.length, 2, 'should stop when cash runs out');
+assert.deepStrictEqual(trades[0], { tradeDate: '2024-01-01', action: 'buy', amount: 10000 });
+assert.deepStrictEqual(trades[1], { tradeDate: '2024-02-01', action: 'buy', amount: 10000 });
+
+// Custom buyAmount
+const trades2 = simulateTrades(history, 15000, { buyAmount: 5000 });
+assert.strictEqual(trades2.length, 3, 'should buy each date with smaller amount');
+assert.deepStrictEqual(trades2[2], { tradeDate: '2024-03-01', action: 'buy', amount: 5000 });
+
 console.log('algorithm tests passed');


### PR DESCRIPTION
## Summary
- implement a simple fixed-amount buy strategy in `simulateTrades`
- test that `simulateTrades` returns expected trade objects

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a85057e28832a858b0a3e6a06af40