### PR TITLE
Add downloadCSV test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "http-server -p 3000 -c-1 .",
     "lint": "eslint .",
     "build": "rm -rf dist && mkdir dist && cp -r src dist && cp public/index.html dist/index.html && cp public/style.css dist/style.css && sed -i 's|../src/main.js|src/main.js|' dist/index.html",
-    "test": "node test/algorithm.test.js && node test/test.js && node test/paifuExporter.test.js && node test/exportCSV.test.js && node test/build.test.js"
+    "test": "node test/algorithm.test.js && node test/test.js && node test/paifuExporter.test.js && node test/exportCSV.test.js && node test/downloadCSV.test.js && node test/build.test.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/test/downloadCSV.test.js
+++ b/test/downloadCSV.test.js
@@ -1,0 +1,42 @@
+import assert from 'assert';
+
+let clicked = false;
+let createdHref = null;
+let createdDownload = null;
+
+global.document = {
+  createElement(tag) {
+    assert.strictEqual(tag, 'a');
+    return {
+      set href(val) { createdHref = val; },
+      set download(val) { createdDownload = val; },
+      click() { clicked = true; }
+    };
+  },
+  addEventListener() {}
+};
+
+let blobData = null;
+const origCreate = URL.createObjectURL;
+const origRevoke = URL.revokeObjectURL;
+URL.createObjectURL = (blob) => {
+  blobData = blob;
+  return 'blob:mock';
+};
+URL.revokeObjectURL = () => {};
+
+const { downloadCSV } = await import('../src/main.js');
+
+await downloadCSV('2024-01', '2024-01', 1000);
+const text = await blobData.text();
+
+assert.strictEqual(createdHref, 'blob:mock');
+assert.strictEqual(createdDownload, 'simulation.csv');
+assert.ok(clicked, 'link should be clicked');
+assert.ok(text.startsWith('Month,Investment,Valuation\n')); 
+assert.ok(text.includes('2024-01,1000,'));
+
+URL.createObjectURL = origCreate;
+URL.revokeObjectURL = origRevoke;
+
+console.log('downloadCSV test passed');


### PR DESCRIPTION
## Summary
- add a test for `downloadCSV` ensuring file download is triggered and CSV data matches expectations
- run the new test along with the rest of the suite

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a8703a9fc832aaeefa76325b06db5