### PR TITLE
Replace sed with Node script for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "http-server -p 3000 -c-1 .",
     "lint": "eslint .",
-    "build": "rm -rf dist && mkdir dist && cp -r src dist && cp public/index.html dist/index.html && cp public/style.css dist/style.css && sed -i 's|../src/main.js|src/main.js|' dist/index.html",
+    "build": "rm -rf dist && mkdir dist && cp -r src dist && cp public/index.html dist/index.html && cp public/style.css dist/style.css && node scripts/updateIndex.js dist/index.html",
     "test": "node test/algorithm.test.js && node test/test.js && node test/paifuExporter.test.js && node test/exportCSV.test.js && node test/build.test.js"
   },
   "devDependencies": {

--- a/scripts/updateIndex.js
+++ b/scripts/updateIndex.js
@@ -1,0 +1,7 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { argv } from 'process';
+
+const file = argv[2] || 'dist/index.html';
+let html = readFileSync(file, 'utf8');
+html = html.replace(/\.\.\/src\/main.js/g, 'src/main.js');
+writeFileSync(file, html);


### PR DESCRIPTION
## Summary
- replace `sed` usage in build script with cross-platform Node script
- add `scripts/updateIndex.js` for updating built `index.html`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a86fedc58832a9216ade44d790a6e