### PR TITLE
Implement build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "http-server -p 3000 -c-1 .",
     "lint": "eslint .",
-    "build": "rm -rf dist && mkdir dist && cp -r src dist && cp public/index.html dist/index.html && cp public/style.css dist/style.css && node scripts/updateIndex.js dist/index.html",
+    "build": "node scripts/build.js",
     "test": "node test/algorithm.test.js && node test/test.js && node test/paifuExporter.test.js && node test/exportCSV.test.js && node test/downloadCSV.test.js && node test/build.test.js"
   },
   "devDependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,16 @@
+import { rmSync, mkdirSync, cpSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dist = join(__dirname, '..', 'dist');
+
+rmSync(dist, { recursive: true, force: true });
+mkdirSync(dist);
+
+cpSync(join(__dirname, '..', 'src'), join(dist, 'src'), { recursive: true });
+cpSync(join(__dirname, '..', 'public', 'index.html'), join(dist, 'index.html'));
+cpSync(join(__dirname, '..', 'public', 'style.css'), join(dist, 'style.css'));
+
+execSync(`node ${join(__dirname, 'updateIndex.js')} ${join(dist, 'index.html')}`, { stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- add `scripts/build.js` for build commands
- use fs API to clean `dist` and copy files
- call `updateIndex.js` from the new build script
- update npm script to run this build helper

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b3d112ca8832a8214dd6668f8c918